### PR TITLE
Update hard-coded test JSON to use Date instead of long.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,14 +151,14 @@
         <configuration>
           <annotationProcessorPaths>
             <path>
-              <groupId>com.ryanharter.auto.value</groupId>
-              <artifactId>auto-value-gson-extension</artifactId>
-              <version>1.3.0</version>
-            </path>
-            <path>
               <groupId>com.google.auto.value</groupId>
               <artifactId>auto-value</artifactId>
               <version>1.7.3</version>
+            </path>
+            <path>
+              <groupId>com.ryanharter.auto.value</groupId>
+              <artifactId>auto-value-gson-extension</artifactId>
+              <version>1.3.0</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -151,14 +151,14 @@
         <configuration>
           <annotationProcessorPaths>
             <path>
-              <groupId>com.google.auto.value</groupId>
-              <artifactId>auto-value</artifactId>
-              <version>1.7.3</version>
-            </path>
-            <path>
               <groupId>com.ryanharter.auto.value</groupId>
               <artifactId>auto-value-gson-extension</artifactId>
               <version>1.3.0</version>
+            </path>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>1.7.3</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/src/main/webapp/transcript.js
+++ b/src/main/webapp/transcript.js
@@ -67,9 +67,9 @@ function appendTextToList(transcriptLine, ulElement) {
   const startDate = new Date(transcriptLine.start);
   const endDate = new Date(transcriptLine.end);
   const startTimestamp = `${startDate.getHours()}:${startDate.getMinutes()}:${
-      startDate.getSeconds()}`;
+    startDate.getSeconds()}`;
   const endTimestamp =
-      `${endDate.getHours()}:${endDate.getMinutes()}:${endDate.getSeconds()}`;
+    `${endDate.getHours()}:${endDate.getMinutes()}:${endDate.getSeconds()}`;
   const timestamp = `${startTimestamp} - ${endTimestamp}`;
 
   appendParagraphToContainer(timestamp, liElement, ['mx-auto']);

--- a/src/main/webapp/transcript.js
+++ b/src/main/webapp/transcript.js
@@ -67,9 +67,9 @@ function appendTextToList(transcriptLine, ulElement) {
   const startDate = new Date(transcriptLine.start);
   const endDate = new Date(transcriptLine.end);
   const startTimestamp = `${startDate.getHours()}:${startDate.getMinutes()}:${
-    startDate.getSeconds()}`;
+      startDate.getSeconds()}`;
   const endTimestamp =
-    `${endDate.getHours()}:${endDate.getMinutes()}:${endDate.getSeconds()}`;
+      `${endDate.getHours()}:${endDate.getMinutes()}:${endDate.getSeconds()}`;
   const timestamp = `${startTimestamp} - ${endTimestamp}`;
 
   appendParagraphToContainer(timestamp, liElement, ['mx-auto']);

--- a/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -50,7 +51,6 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import java.util.Date;
 
 @RunWith(JUnit4.class)
 public final class TranscriptServletTest {
@@ -74,30 +74,30 @@ public final class TranscriptServletTest {
   private static final String SHORT_VIDEO_ID = "Obgnr9pc820";
   private static final String LONG_VIDEO_ID = "jNQXAC9IVRw";
   private static final String SHORT_VIDEO_JSON = "[{\"key\":{\"kind\":\"TranscriptLine\",\"id\":"
-  + "1},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:00 AM\","
-  + "\"duration\":\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:01 AM\",\"content\":"
-  + "\" \"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\","
-  + "\"id\":123},\"start\":\"Jan 1, 1970 12:00:02 AM\",\"duration\":\"Jan 1, 1970 12:00:01 AM\","
-  + "\"end\":\"Jan 1, 1970 12:00:03 AM\",\"content\":\"Hi\"},{\"key\":{\"kind\":\"TranscriptLine\","
-  + "\"id\":3},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:05 AM\","
-  + "\"duration\":\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:06 AM\",\"content\":\"Okay\"}]";
+      + "1},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:00 AM\","
+      + "\"duration\":\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:01 AM\",\"content\":"
+      + "\" \"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\","
+      + "\"id\":123},\"start\":\"Jan 1, 1970 12:00:02 AM\",\"duration\":\"Jan 1, 1970 12:00:01 AM\","
+      + "\"end\":\"Jan 1, 1970 12:00:03 AM\",\"content\":\"Hi\"},{\"key\":{\"kind\":\"TranscriptLine\","
+      + "\"id\":3},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:05 AM\","
+      + "\"duration\":\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:06 AM\",\"content\":\"Okay\"}]";
   private static final String LONG_VIDEO_JSON = "[{\"key\":{\"kind\":\"TranscriptLine\",\"id\":1}"
-  + ",\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:01 AM\","
-  + "\"duration\":\"Jan 1, 1970 12:00:03 AM\",\"end\":\"Jan 1, 1970 12:00:04 AM\",\"content\""
-  + ":\"All right, so here we are\\nin front of the elephants,\"},{\"key\":{\"kind\":"
-  + "\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\",\"id\":123}"
-  + ",\"start\":\"Jan 1, 1970 12:00:04 AM\",\"duration\":\"Jan 1, 1970 12:00:04 AM\","
-  + "\"end\":\"Jan 1, 1970 12:00:09 AM\",\"content\":\"the cool thing about these "
-  + "guys\\nis that they have really,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":3},"
-  + "\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:09 AM\","
-  + "\"duration\":\"Jan 1, 1970 12:00:03 AM\",\"end\":\"Jan 1, 1970 12:00:12 AM\",\"content\":"
-  + "\"really, really long trunks,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":4},\"lecture\""
-  + ":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:12 AM\",\"duration\":\"Jan "
-  + "1, 1970 12:00:04 AM\",\"end\":\"Jan 1, 1970 12:00:17 AM\",\"content\":\"and that&#39;s, "
-  + "that&#39;s cool.\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":5},\"lecture\""
-  + ":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:17 AM\",\"duration\":"
-  + "\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:18 AM\",\"content\""
-  + ":\"And that&#39;s pretty much all there is to say.\"}]";
+      + ",\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:01 AM\","
+      + "\"duration\":\"Jan 1, 1970 12:00:03 AM\",\"end\":\"Jan 1, 1970 12:00:04 AM\",\"content\""
+      + ":\"All right, so here we are\\nin front of the elephants,\"},{\"key\":{\"kind\":"
+      + "\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\",\"id\":123}"
+      + ",\"start\":\"Jan 1, 1970 12:00:04 AM\",\"duration\":\"Jan 1, 1970 12:00:04 AM\","
+      + "\"end\":\"Jan 1, 1970 12:00:09 AM\",\"content\":\"the cool thing about these "
+      + "guys\\nis that they have really,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":3},"
+      + "\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:09 AM\","
+      + "\"duration\":\"Jan 1, 1970 12:00:03 AM\",\"end\":\"Jan 1, 1970 12:00:12 AM\",\"content\":"
+      + "\"really, really long trunks,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":4},\"lecture\""
+      + ":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:12 AM\",\"duration\":\"Jan "
+      + "1, 1970 12:00:04 AM\",\"end\":\"Jan 1, 1970 12:00:17 AM\",\"content\":\"and that&#39;s, "
+      + "that&#39;s cool.\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":5},\"lecture\""
+      + ":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:17 AM\",\"duration\":"
+      + "\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:18 AM\",\"content\""
+      + ":\"And that&#39;s pretty much all there is to say.\"}]";
 
   @Before
   public void setUp() throws ServletException, IOException {
@@ -238,7 +238,8 @@ public final class TranscriptServletTest {
       // Set dummy values because AutoValue needs all the values to create a TranscriptLine object.
       lineEntity.setProperty(TranscriptLine.PROP_START, new Date());
       lineEntity.setProperty(TranscriptLine.PROP_DURATION, new Date());
-      lineEntity.setProperty(TranscriptLine.PROP_CONTENT, new Date());
+      lineEntity.setProperty(TranscriptLine.PROP_CONTENT, "");
+      lineEntity.setProperty(TranscriptLine.PROP_END, new Date());
       datastore.put(lineEntity);
     }
   }

--- a/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
@@ -50,6 +50,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import java.util.Date;
 
 @RunWith(JUnit4.class)
 public final class TranscriptServletTest {
@@ -72,28 +73,31 @@ public final class TranscriptServletTest {
 
   private static final String SHORT_VIDEO_ID = "Obgnr9pc820";
   private static final String LONG_VIDEO_ID = "jNQXAC9IVRw";
-  private static final String SHORT_VIDEO_JSON = "[{\"key\":{\"kind\":\"TranscriptLine\",\"id\":1},"
-      + "\"lecture\":{\"kind\":\"lecture\",\"id\":123},"
-      + "\"start\":\"0.4\",\"duration\":\"1\",\"content\":\" \"},"
-      + "{\"key\":{\"kind\":\"TranscriptLine\",\"id\":2},\"lecture\":"
-      + "{\"kind\":\"lecture\",\"id\":123},\"start\":\"2.28\",\"duration\":\"1\",\"content\""
-      + ":\"Hi\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":3},\"lecture\":"
-      + "{\"kind\":\"lecture\",\"id\":123},\"start\":\"5.04\",\"duration\":\"1.6\","
-      + "\"content\":\"Okay\"}]";
-  private static final String LONG_VIDEO_JSON =
-      "[{\"key\":{\"kind\":\"TranscriptLine\",\"id\":1},\"lecture\":"
-      + "{\"kind\":\"lecture\",\"id\":123},\"start\":\"1.3\",\"duration\":"
-      + "\"3.1\",\"content\":\"All right, so here we are\\nin front of the "
-      + "elephants,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":4},\"lecture\":"
-      + "{\"kind\":\"lecture\",\"id\":123},\"start\":\"12.7\",\"duration\":\"4.3\",\"content\":"
-      + "\"and that&#39;s, that&#39;s cool.\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":5},"
-      + "\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"17\",\"duration\":\"1.767\",\""
-      + "content\":\"And that&#39;s pretty much all there is to say.\"},{\"key\":{\"kind\""
-      + ":\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":"
-      + "\"4.4\",\"duration\":\"4.766\",\"content\":\"the cool thing about these guys\\nis that "
-      + "they have really,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":3},\"lecture\":"
-      + "{\"kind\":\"lecture\",\"id\":123},\"start\":\"9.166\",\"duration\":\"3.534\","
-      + "\"content\":\"really, really long trunks,\"}]";
+  private static final String SHORT_VIDEO_JSON = "[{\"key\":{\"kind\":\"TranscriptLine\",\"id\":"
+  + "1},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:00 AM\","
+  + "\"duration\":\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:01 AM\",\"content\":"
+  + "\" \"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\","
+  + "\"id\":123},\"start\":\"Jan 1, 1970 12:00:02 AM\",\"duration\":\"Jan 1, 1970 12:00:01 AM\","
+  + "\"end\":\"Jan 1, 1970 12:00:03 AM\",\"content\":\"Hi\"},{\"key\":{\"kind\":\"TranscriptLine\","
+  + "\"id\":3},\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:05 AM\","
+  + "\"duration\":\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:06 AM\",\"content\":\"Okay\"}]";
+  private static final String LONG_VIDEO_JSON = "[{\"key\":{\"kind\":\"TranscriptLine\",\"id\":1}"
+  + ",\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:01 AM\","
+  + "\"duration\":\"Jan 1, 1970 12:00:03 AM\",\"end\":\"Jan 1, 1970 12:00:04 AM\",\"content\""
+  + ":\"All right, so here we are\\nin front of the elephants,\"},{\"key\":{\"kind\":"
+  + "\"TranscriptLine\",\"id\":2},\"lecture\":{\"kind\":\"lecture\",\"id\":123}"
+  + ",\"start\":\"Jan 1, 1970 12:00:04 AM\",\"duration\":\"Jan 1, 1970 12:00:04 AM\","
+  + "\"end\":\"Jan 1, 1970 12:00:09 AM\",\"content\":\"the cool thing about these "
+  + "guys\\nis that they have really,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":3},"
+  + "\"lecture\":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:09 AM\","
+  + "\"duration\":\"Jan 1, 1970 12:00:03 AM\",\"end\":\"Jan 1, 1970 12:00:12 AM\",\"content\":"
+  + "\"really, really long trunks,\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":4},\"lecture\""
+  + ":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:12 AM\",\"duration\":\"Jan "
+  + "1, 1970 12:00:04 AM\",\"end\":\"Jan 1, 1970 12:00:17 AM\",\"content\":\"and that&#39;s, "
+  + "that&#39;s cool.\"},{\"key\":{\"kind\":\"TranscriptLine\",\"id\":5},\"lecture\""
+  + ":{\"kind\":\"lecture\",\"id\":123},\"start\":\"Jan 1, 1970 12:00:17 AM\",\"duration\":"
+  + "\"Jan 1, 1970 12:00:01 AM\",\"end\":\"Jan 1, 1970 12:00:18 AM\",\"content\""
+  + ":\"And that&#39;s pretty much all there is to say.\"}]";
 
   @Before
   public void setUp() throws ServletException, IOException {
@@ -232,9 +236,9 @@ public final class TranscriptServletTest {
       Entity lineEntity = new Entity(TranscriptLine.ENTITY_KIND);
       lineEntity.setProperty(TranscriptLine.PROP_LECTURE, lectureKey);
       // Set dummy values because AutoValue needs all the values to create a TranscriptLine object.
-      lineEntity.setProperty(TranscriptLine.PROP_START, "");
-      lineEntity.setProperty(TranscriptLine.PROP_DURATION, "");
-      lineEntity.setProperty(TranscriptLine.PROP_CONTENT, "");
+      lineEntity.setProperty(TranscriptLine.PROP_START, new Date());
+      lineEntity.setProperty(TranscriptLine.PROP_DURATION, new Date());
+      lineEntity.setProperty(TranscriptLine.PROP_CONTENT, new Date());
       datastore.put(lineEntity);
     }
   }


### PR DESCRIPTION
After switching to storing the start, end, and duration as dates, the hard-coded JSON used for testing is no longer accurate. This pull request updates the hard-coded strings and helper methods to reflect this change.