### PR TITLE
Update transcript methods to use the Lecture Key rather than the Lecture Id.

### DIFF
--- a/src/main/java/com/googleinterns/zoomtube/servlets/TranscriptServlet.java
+++ b/src/main/java/com/googleinterns/zoomtube/servlets/TranscriptServlet.java
@@ -69,7 +69,8 @@ public class TranscriptServlet extends HttpServlet {
     String videoId = request.getParameter(LectureUtil.VIDEO_ID);
     Document document = getTranscriptXmlAsDocument(videoId).get();
     long lectureId = Long.parseLong(request.getParameter(LectureUtil.ID));
-    putTranscriptLinesInDatastore(lectureId, document);
+    Key lectureKey = KeyFactory.createKey(LectureUtil.KIND, lectureId);
+    putTranscriptLinesInDatastore(lectureKey, document);
   }
 
   /**
@@ -96,10 +97,10 @@ public class TranscriptServlet extends HttpServlet {
   /**
    * Puts each transcript line from {@code document} in datastore as its own entity.
    *
-   * @param lectureId Indicates the lecture id to group the transcript lines under.
+   * @param lectureKey Indicates the lecture key to group the transcript lines under.
    * @param document The XML file containing the transcript lines.
    */
-  private void putTranscriptLinesInDatastore(long lectureId, Document document) {
+  private void putTranscriptLinesInDatastore(Key lectureKey, Document document) {
     NodeList transcriptNodes = document.getElementsByTagName(TAG_TEXT);
     for (int nodeIndex = 0; nodeIndex < transcriptNodes.getLength(); nodeIndex++) {
       Node transcriptNode = transcriptNodes.item(nodeIndex);
@@ -109,7 +110,7 @@ public class TranscriptServlet extends HttpServlet {
       Float lineDuration = Float.parseFloat(transcriptElement.getAttribute(ATTR_DURATION));
       Float lineEnd = lineStart.floatValue() + lineDuration.floatValue();
       datastore.put(TranscriptLineUtil.createEntity(
-          lectureId, lineContent, lineStart, lineDuration, lineEnd));
+          lectureKey, lineContent, lineStart, lineDuration, lineEnd));
     }
   }
 

--- a/src/main/java/com/googleinterns/zoomtube/utils/TranscriptLineUtil.java
+++ b/src/main/java/com/googleinterns/zoomtube/utils/TranscriptLineUtil.java
@@ -16,7 +16,6 @@ package com.googleinterns.zoomtube.utils;
 
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.datastore.KeyFactory;
 import com.googleinterns.zoomtube.data.TranscriptLine;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -61,9 +60,9 @@ public final class TranscriptLineUtil {
    * @param lineEnd The ending timestamp for the transcript line in seconds.
    */
   public static Entity createEntity(
-      long lectureId, String lineContent, Float lineStart, Float lineDuration, Float lineEnd) {
+      Key lectureKey, String lineContent, Float lineStart, Float lineDuration, Float lineEnd) {
     Entity lineEntity = new Entity(KIND);
-    lineEntity.setProperty(LECTURE, KeyFactory.createKey(LectureUtil.KIND, lectureId));
+    lineEntity.setProperty(LECTURE, lectureKey);
     lineEntity.setProperty(CONTENT, lineContent);
     lineEntity.setProperty(START, new Date(TimeUnit.SECONDS.toMillis(lineStart.longValue())));
     lineEntity.setProperty(DURATION, new Date(TimeUnit.SECONDS.toMillis(lineDuration.longValue())));

--- a/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
@@ -238,7 +238,8 @@ public final class TranscriptServletTest {
 
   private void putTranscriptLinesInDatastore(List<TranscriptLine> transcriptLines, long lectureId) {
     for (int i = 0; i < transcriptLines.size(); i++) {
-      Entity lineEntity = TranscriptLineUtil.createEntity(lectureId, "test content",
+      Key lectureKey = KeyFactory.createKey(LectureUtil.KIND, lectureId);
+      Entity lineEntity = TranscriptLineUtil.createEntity(lectureKey, "test content",
           /* start= */ 0F, /* duration= */ 0F, /* end= */ 0F);
       datastore.put(lineEntity);
     }

--- a/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/TranscriptServletTest.java
@@ -106,6 +106,8 @@ public final class TranscriptServletTest {
 
   private static List<TranscriptLine> shortVideoTranscriptLines;
   private static List<TranscriptLine> longVideoTranscriptLines;
+  private static Key lectureKeyA;
+  private static Key lectureKeyB;
 
   @BeforeClass
   public static void createTranscriptLineLists() {
@@ -122,6 +124,8 @@ public final class TranscriptServletTest {
     lectureTranscript = new StringWriter();
     PrintWriter writer = new PrintWriter(lectureTranscript);
     when(response.getWriter()).thenReturn(writer);
+    lectureKeyA = KeyFactory.createKey(LectureUtil.KIND, LECTURE_ID_A);
+    lectureKeyB = KeyFactory.createKey(LectureUtil.KIND, LECTURE_ID_B);
   }
 
   @After
@@ -131,7 +135,7 @@ public final class TranscriptServletTest {
 
   @Test
   public void doGet_getDataInDatastoreForShortVideo() throws ServletException, IOException {
-    putTranscriptLinesInDatastore(shortVideoTranscriptLines, LECTURE_ID_A);
+    putTranscriptLinesInDatastore(shortVideoTranscriptLines, lectureKeyA);
     when(request.getParameter(LectureUtil.ID)).thenReturn(LECTURE_ID_A.toString());
 
     transcriptServlet.doGet(request, response);
@@ -181,7 +185,7 @@ public final class TranscriptServletTest {
 
   @Test
   public void doGet_returnsLectureForLongVideoFromDatastore() throws ServletException, IOException {
-    putTranscriptLinesInDatastore(longVideoTranscriptLines, LECTURE_ID_A);
+    putTranscriptLinesInDatastore(longVideoTranscriptLines, lectureKeyA);
     when(request.getParameter(LectureUtil.ID)).thenReturn(LECTURE_ID_A.toString());
 
     transcriptServlet.doGet(request, response);
@@ -206,8 +210,8 @@ public final class TranscriptServletTest {
   @Test
   public void doGet_onlyOtherLecturesInDatastore_GetNoLectures()
       throws ServletException, IOException {
-    putTranscriptLinesInDatastore(shortVideoTranscriptLines, LECTURE_ID_B);
-    putTranscriptLinesInDatastore(longVideoTranscriptLines, LECTURE_ID_A);
+    putTranscriptLinesInDatastore(shortVideoTranscriptLines, lectureKeyB);
+    putTranscriptLinesInDatastore(longVideoTranscriptLines, lectureKeyA);
     when(request.getParameter(LectureUtil.ID)).thenReturn(LECTURE_ID_C.toString());
 
     transcriptServlet.doGet(request, response);
@@ -219,8 +223,8 @@ public final class TranscriptServletTest {
   @Test
   public void doGet_twoLecturesInDatastore_returnsOneLecture()
       throws ServletException, IOException {
-    putTranscriptLinesInDatastore(shortVideoTranscriptLines, LECTURE_ID_B);
-    putTranscriptLinesInDatastore(longVideoTranscriptLines, LECTURE_ID_A);
+    putTranscriptLinesInDatastore(shortVideoTranscriptLines, lectureKeyB);
+    putTranscriptLinesInDatastore(longVideoTranscriptLines, lectureKeyA);
     when(request.getParameter(LectureUtil.ID)).thenReturn(LECTURE_ID_A.toString());
 
     transcriptServlet.doGet(request, response);
@@ -236,9 +240,8 @@ public final class TranscriptServletTest {
         transcriptLinesJson, (new ArrayList<List<TranscriptLine>>().getClass()));
   }
 
-  private void putTranscriptLinesInDatastore(List<TranscriptLine> transcriptLines, long lectureId) {
+  private void putTranscriptLinesInDatastore(List<TranscriptLine> transcriptLines, Key lectureKey) {
     for (int i = 0; i < transcriptLines.size(); i++) {
-      Key lectureKey = KeyFactory.createKey(LectureUtil.KIND, lectureId);
       Entity lineEntity = TranscriptLineUtil.createEntity(lectureKey, "test content",
           /* start= */ 0F, /* duration= */ 0F, /* end= */ 0F);
       datastore.put(lineEntity);

--- a/src/test/java/com/googleinterns/zoomtube/utils/TranscriptLineUtilTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/utils/TranscriptLineUtilTest.java
@@ -81,7 +81,7 @@ public final class TranscriptLineUtilTest {
     final Float startDate = 23.32F;
     final Float duration = 23.32F;
     final Float endDate = startDate.floatValue() + duration.floatValue();
-    Key lectureKeyA = KeyFactory.createKey(LectureUtil.KIND, LECTURE_ID_A);
+    final Key lectureKeyA = KeyFactory.createKey(LectureUtil.KIND, LECTURE_ID_A);
     Entity actualEntity =
         TranscriptLineUtil.createEntity(lectureKeyA, TEST_CONTENT, startDate, duration, endDate);
 

--- a/src/test/java/com/googleinterns/zoomtube/utils/TranscriptLineUtilTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/utils/TranscriptLineUtilTest.java
@@ -81,9 +81,9 @@ public final class TranscriptLineUtilTest {
     final Float startDate = 23.32F;
     final Float duration = 23.32F;
     final Float endDate = startDate.floatValue() + duration.floatValue();
-
+    Key lectureKeyA = KeyFactory.createKey(LectureUtil.KIND, LECTURE_ID_A);
     Entity actualEntity =
-        TranscriptLineUtil.createEntity(LECTURE_ID_A, TEST_CONTENT, startDate, duration, endDate);
+        TranscriptLineUtil.createEntity(lectureKeyA, TEST_CONTENT, startDate, duration, endDate);
 
     assertThat(actualEntity.getProperty(TranscriptLineUtil.CONTENT)).isEqualTo(TEST_CONTENT);
     Key actualKey = KeyFactory.createKey(LectureUtil.KIND, LECTURE_ID_A);


### PR DESCRIPTION
This change is needed because `lectureServlet` keeps a reference to the lecture key rather than the lecture id. When `lectureServlet` calls the method from `TranscriptServlet` for parsing the transcript, it would only be able to pass the key.