### PR TITLE
Automatically Scroll the Transcript as a Video Plays Forward Without Seeking Backwards

### DIFF
--- a/src/main/webapp/timestamps.js
+++ b/src/main/webapp/timestamps.js
@@ -43,10 +43,10 @@ function timestampToSeconds(timestamp) {
   return totalSeconds;
 }
 
-
 /**
  * Returns the {@code date} in seconds.
  */
 function getDateInSeconds(date) {
-  return date.getSeconds() + date.getMinutes() * MINUTES_TO_SECONDS + date.getHours() * HOURS_TO_SECONDS;
+  return date.getSeconds() + date.getMinutes() * MINUTES_TO_SECONDS +
+      date.getHours() * HOURS_TO_SECONDS;
 }

--- a/src/main/webapp/timestamps.js
+++ b/src/main/webapp/timestamps.js
@@ -39,3 +39,11 @@ function timestampToSeconds(timestamp) {
   const totalSeconds = totalMilliseconds / 1000;
   return totalSeconds;
 }
+
+
+/**
+ * Returns the {@code date} in seconds.
+ */
+function getDateInSeconds(date) {
+  return date.getSeconds() + date.getMinutes() * 60 + date.getHours() * 360
+}

--- a/src/main/webapp/timestamps.js
+++ b/src/main/webapp/timestamps.js
@@ -44,7 +44,7 @@ function timestampToSeconds(timestamp) {
 }
 
 /**
- * Returns the {@code date} in seconds {number}.
+ * @return {number} The {@code date} in seconds.
  */
 // TODO: Remove this method once the pull request updating
 // Date to long is approved.

--- a/src/main/webapp/timestamps.js
+++ b/src/main/webapp/timestamps.js
@@ -44,8 +44,10 @@ function timestampToSeconds(timestamp) {
 }
 
 /**
- * Returns the {@code date} in seconds.
+ * Returns the {@code date} in seconds {number}.
  */
+// TODO: Remove this method once the pull request updating
+// Date to long is approved.
 function getDateInSeconds(date) {
   return date.getSeconds() + date.getMinutes() * MINUTES_TO_SECONDS +
       date.getHours() * HOURS_TO_SECONDS;

--- a/src/main/webapp/timestamps.js
+++ b/src/main/webapp/timestamps.js
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const MINUTES_TO_SECONDS = 60;
+const HOURS_TO_SECONDS = 360;
+
 /**
  * Coverts a Date representing a video {@code timestamp} into a string.
  */
@@ -45,5 +48,5 @@ function timestampToSeconds(timestamp) {
  * Returns the {@code date} in seconds.
  */
 function getDateInSeconds(date) {
-  return date.getSeconds() + date.getMinutes() * 60 + date.getHours() * 360
+  return date.getSeconds() + date.getMinutes() * MINUTES_TO_SECONDS + date.getHours() * HOURS_TO_SECONDS;
 }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -119,7 +119,8 @@ function deleteTranscript() {
 
 /** Seeks transcript to {@code currentTime}, which is given in seconds. */
 function seekTranscript(currentTime) {
-  const currentTimestamp = window.getDateInSeconds(currentTranscriptLine.endDate);
+  const currentTimestamp =
+      window.getDateInSeconds(currentTranscriptLine.endDate);
   if (currentTime <= currentTimestamp) {
     return;
   }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 
-const /** @const {string} */ TRANSCRIPT_CONTAINER =
-    'transcript-lines-container';
-const /** @const {string} */ ENDPOINT_TRANSCRIPT = '/transcript';
+const TRANSCRIPT_CONTAINER = 'transcript-lines-container';
+const ENDPOINT_TRANSCRIPT = '/transcript';
 
 let /** Element */ currentTranscriptLine;
 

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -125,8 +125,10 @@ function seekTranscript(currentTime) {
   const currentTranscriptLineEndTimeInSeconds =
       currentTranscriptLine.endDate.getTime() / 1000;
   if (roundedCurrentTime < currentTranscriptLineEndTimeInSeconds) {
+    console.log('same timestamp');
     return;
   }
+  console.log('different timestamp');
   // TODO: disable highlighting on the currentTranscriptLine
   currentTranscriptLine = currentTranscriptLine.nextElementSibling;
   currentTranscriptLine.scrollIntoView();

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 const TRANSCRIPT_CONTAINER = 'transcript-lines-container';
 const ENDPOINT_TRANSCRIPT = '/transcript';
 

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** @const {string} */
 const TRANSCRIPT_CONTAINER = 'transcript-lines-container';
 const ENDPOINT_TRANSCRIPT = '/transcript';
 
-let currentTranscriptLine;
+let /** Object */ currentTranscriptLine;
 
 /**
  * Sends a POST request to the transcript.
@@ -119,13 +120,15 @@ function deleteTranscript() {
 
 /** Seeks transcript to {@code currentTime}, which is given in seconds. */
 function seekTranscript(currentTime) {
+  // TODO: Update this constant once the pull request updating Date to long
+  // is approved.
   const currentTimestamp =
       window.getDateInSeconds(currentTranscriptLine.endDate);
   if (currentTime <= currentTimestamp) {
     return;
   }
-  // TODO: disable highlighting on the currentTranscriptLine
+  // TODO: Disable highlighting on the currentTranscriptLine
   currentTranscriptLine = currentTranscriptLine.nextElementSibling;
   currentTranscriptLine.scrollIntoView();
-  // TODO: handle the case where the video isn't only playing.
+  // TODO: Handle the case where the video isn't only playing.
 }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -58,7 +58,6 @@ function addMultipleTranscriptLinesToDom(transcriptLines) {
   transcriptContainer.appendChild(ulElement);
 
   transcriptLines.forEach((transcriptLine) => {
-    if (currentTranscriptLine === 'undefined')
     appendTextToList(transcriptLine, ulElement);
   });
 }
@@ -88,6 +87,11 @@ function appendTextToList(transcriptLine, ulElement) {
   ulElement.appendChild(liElement);
   // Save the dates for seeking later.
   liElement.startDate = new Date(transcriptLine.start);
+  liElement.endDate = new Date(transcriptLine.end);
+  // Sets the current transcript line to be the first line.
+  if (currentTranscriptLine == undefined) {
+    currentTranscriptLine = liElement;
+  }
 }
 
 /**
@@ -114,7 +118,17 @@ function deleteTranscript() {
   fetch('/delete-transcript', {method: 'POST'});
 }
 
-/** Seeks transcript to {@code currentTime}. */
+/** Seeks transcript to {@code currentTime}, which is given in seconds. */
 function seekTranscript(currentTime) {
-
+  // The transcript timestamp doesn't keep track of decimals for the seconds.
+  const roundedCurrentTime = Math.round(currentTime);
+  const currentTranscriptLineEndTimeInSeconds =
+      currentTranscriptLine.endDate.getTime() / 1000;
+  if (roundedCurrentTime < currentTranscriptLineEndTimeInSeconds) {
+    return;
+  }
+  // TODO: disable highlighting on the currentTranscriptLine
+  currentTranscriptLine = currentTranscriptLine.nextElementSibling;
+  currentTranscriptLine.scrollIntoView();
+  // TODO: handle the case where the video isn't only playing.
 }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 
-const /** @const {string} */ TRANSCRIPT_CONTAINER = 'transcript-lines-container';
+const /** @const {string} */ TRANSCRIPT_CONTAINER =
+    'transcript-lines-container';
 const /** @const {string} */ ENDPOINT_TRANSCRIPT = '/transcript';
 
 let /** Element */ currentTranscriptLine;

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** @const {string} */
-const TRANSCRIPT_CONTAINER = 'transcript-lines-container';
-const ENDPOINT_TRANSCRIPT = '/transcript';
 
-let /** Object */ currentTranscriptLine;
+const /** @const {string} */ TRANSCRIPT_CONTAINER = 'transcript-lines-container';
+const /** @const {string} */ ENDPOINT_TRANSCRIPT = '/transcript';
+
+let /** Element */ currentTranscriptLine;
 
 /**
  * Sends a POST request to the transcript.
@@ -89,7 +89,7 @@ function appendTextToList(transcriptLine, ulElement) {
   liElement.startDate = new Date(transcriptLine.start);
   liElement.endDate = new Date(transcriptLine.end);
   // Sets the current transcript line to be the first line.
-  if (currentTranscriptLine == undefined) {
+  if (currentTranscriptLine == null) {
     currentTranscriptLine = liElement;
   }
 }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -16,6 +16,8 @@
 const TRANSCRIPT_CONTAINER = 'transcript-lines-container';
 const ENDPOINT_TRANSCRIPT = '/transcript';
 
+let currentTranscriptLine;
+
 /**
  * Sends a POST request to the transcript.
  */
@@ -56,6 +58,7 @@ function addMultipleTranscriptLinesToDom(transcriptLines) {
   transcriptContainer.appendChild(ulElement);
 
   transcriptLines.forEach((transcriptLine) => {
+    if (currentTranscriptLine === 'undefined')
     appendTextToList(transcriptLine, ulElement);
   });
 }
@@ -113,6 +116,5 @@ function deleteTranscript() {
 
 /** Seeks transcript to {@code currentTime}. */
 function seekTranscript(currentTime) {
-  // TODO: Remove and implement.
-  console.log('SEEKING TRANSCRIPT TO: ' + currentTime);
+
 }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -1,4 +1,3 @@
-
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,7 +119,7 @@ function deleteTranscript() {
 
 /** Seeks transcript to {@code currentTime}, which is given in seconds. */
 function seekTranscript(currentTime) {
-  const currentTimestamp = getDateInSeconds(currentTranscriptLine.endDate);
+  const currentTimestamp = window.getDateInSeconds(currentTranscriptLine.endDate);
   if (currentTime <= currentTimestamp) {
     return;
   }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -120,15 +120,10 @@ function deleteTranscript() {
 
 /** Seeks transcript to {@code currentTime}, which is given in seconds. */
 function seekTranscript(currentTime) {
-  // The transcript timestamp doesn't keep track of decimals for the seconds.
-  const roundedCurrentTime = Math.round(currentTime);
-  const currentTranscriptLineEndTimeInSeconds =
-      currentTranscriptLine.endDate.getTime() / 1000;
-  if (roundedCurrentTime < currentTranscriptLineEndTimeInSeconds) {
-    console.log('same timestamp');
+  const currentTimestamp = getDateInSeconds(currentTranscriptLine.endDate);
+  if (currentTime <= currentTimestamp) {
     return;
   }
-  console.log('different timestamp');
   // TODO: disable highlighting on the currentTranscriptLine
   currentTranscriptLine = currentTranscriptLine.nextElementSibling;
   currentTranscriptLine.scrollIntoView();

--- a/src/main/webapp/view/view.js
+++ b/src/main/webapp/view/view.js
@@ -26,9 +26,9 @@ initialize();
  * and transcript sections for the lecture view page.
  */
 async function initialize() {
+  window.loadTranscript(window.location.search);
   window.loadVideoApi();
   window.intializeDiscussion();
-  window.loadTranscript(window.location.search);
 }
 
 /**

--- a/src/main/webapp/view/view.js
+++ b/src/main/webapp/view/view.js
@@ -26,9 +26,9 @@ initialize();
  * and transcript sections for the lecture view page.
  */
 async function initialize() {
-  window.loadTranscript(window.location.search);
   window.loadVideoApi();
   window.intializeDiscussion();
+  window.loadTranscript(window.location.search);
 }
 
 /**


### PR DESCRIPTION
The transcript now automatically scrolls as the video is playing.

Video of auto scrolling: https://drive.google.com/file/d/1SQaRidffvOQgaoPJA58chcxL5Mrwok1T/view?usp=sharing

Issues that will be fixed later:
- Transcript sometimes scrolls to the next line prematurely
  - This can be mitigated by having the current transcript line be the second line visible in the transcript box rather than the first.
- Users can not scroll on their own while the video is playing. The transcript will scroll back to where it is supposed to be once it is time to scroll to the next line.