### PR TITLE
Fix bug in which the first transcript line is not highlighted.

### DIFF
--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -126,7 +126,7 @@ function seekTranscript(currentTime) {
   // TODO: Handle the case where the video isn't only playing.
 }
 
-/** 
+/**
  * Bolds the text in `transcriptLineLiElement` if it is not already
  * bolded.
  */

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -115,8 +115,7 @@ function seekTranscript(currentTime) {
   if (currentTimeMs < currentTranscriptLine.startTimestampMs) {
     return;
   }
-  if (currentTranscriptLine.startTimestampMs <= currentTimeMs &&
-      currentTimeMs <= currentTranscriptLine.endTimestampMs) {
+  if (isWithinCurrentTimeRange(currentTimeMs)) {
     if (!isBolded(currentTranscriptLine)) {
       addBold(currentTranscriptLine);
     }
@@ -146,9 +145,13 @@ function isBolded(transcriptLineLiElement) {
   return transcriptLineLiElement.classList.contains(BOLD_FONT_WEIGHT);
 }
 
+/**
+ * Checks if `currentTimeMs` is within the time range for
+ * the current transcript line.
+ * */
 function isWithinCurrentTimeRange(currentTimeMs) {
   return currentTranscriptLine.startTimestampMs <= currentTimeMs &&
-  currentTimeMs <= currentTranscriptLine.endTimestampMs;
+      currentTimeMs <= currentTranscriptLine.endTimestampMs;
 }
 
 /**

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -152,7 +152,6 @@ function isBolded(transcriptLineLiElement) {
 /**
  * Returns true if `currentTimeMs` is within the time range for
  * the current transcript line.
- *
  */
 function isWithinCurrentTimeRange(currentTimeMs) {
   return currentTranscriptLine.startTimestampMs <= currentTimeMs &&

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -152,7 +152,7 @@ function isBolded(transcriptLineLiElement) {
 /**
  * Returns true if `currentTimeMs` is within the time range for
  * the current transcript line.
- * 
+ *
  */
 function isWithinCurrentTimeRange(currentTimeMs) {
   return currentTranscriptLine.startTimestampMs <= currentTimeMs &&

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -114,6 +114,9 @@ function seekTranscript(currentTime) {
   const currentTimeMs = window.secondsToMilliseconds(currentTime);
   if (currentTimeMs <= currentTranscriptLine.endTimestampMs) {
     return;
+  } else if (currentTime > currentTranscriptLine.startTimestampMs && isBolded(currentTranscriptLine)) {
+    removeBold(currentTranscriptLine);
+    return;
   }
   removeBold(currentTranscriptLine);
   currentTranscriptLine = currentTranscriptLine.nextElementSibling;
@@ -132,6 +135,11 @@ function addBold(transcriptLineLiElement) {
 function removeBold(transcriptLineLiElement) {
   transcriptLineLiElement.classList.add(DEFAULT_FONT_WEIGHT);
   transcriptLineLiElement.classList.remove(BOLD_FONT_WEIGHT);
+}
+
+/** Checks if `transcriptLineLiElement` is bolded. */
+function isBolded(transcriptLineLiElement) {
+  return transcriptLineLiElement.classList.contains(BOLD_FONT_WEIGHT);
 }
 
 /**

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -116,9 +116,7 @@ function seekTranscript(currentTime) {
     return;
   }
   if (isWithinCurrentTimeRange(currentTimeMs)) {
-    if (!isBolded(currentTranscriptLine)) {
-      addBold(currentTranscriptLine);
-    }
+    addBold(currentTranscriptLine);
     return;
   }
   removeBold(currentTranscriptLine);
@@ -130,23 +128,29 @@ function seekTranscript(currentTime) {
 
 /** Bolds the text in `transcriptLineLiElement` */
 function addBold(transcriptLineLiElement) {
+  if (isBolded) {
+    return;
+  }
   transcriptLineLiElement.classList.add(BOLD_FONT_WEIGHT);
   transcriptLineLiElement.classList.remove(DEFAULT_FONT_WEIGHT);
 }
 
 /** Removes bold from the text in `transcriptLineLiElement` */
 function removeBold(transcriptLineLiElement) {
+  if (!isBolded) {
+    return;
+  }
   transcriptLineLiElement.classList.add(DEFAULT_FONT_WEIGHT);
   transcriptLineLiElement.classList.remove(BOLD_FONT_WEIGHT);
 }
 
-/** Checks if `transcriptLineLiElement` is bolded. */
+/** Returns true if`transcriptLineLiElement` is bolded. */
 function isBolded(transcriptLineLiElement) {
   return transcriptLineLiElement.classList.contains(BOLD_FONT_WEIGHT);
 }
 
 /**
- * Checks if `currentTimeMs` is within the time range for
+ * Returns true if `currentTimeMs` is within the time range for
  * the current transcript line.
  * */
 function isWithinCurrentTimeRange(currentTimeMs) {

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -112,10 +112,14 @@ function deleteTranscript() {
 /** Seeks transcript to {@code currentTime}, which is given in seconds. */
 function seekTranscript(currentTime) {
   const currentTimeMs = window.secondsToMilliseconds(currentTime);
-  if (currentTimeMs <= currentTranscriptLine.endTimestampMs) {
+  if (currentTimeMs < currentTranscriptLine.startTimestampMs) {
     return;
-  } else if (currentTime > currentTranscriptLine.startTimestampMs && isBolded(currentTranscriptLine)) {
-    removeBold(currentTranscriptLine);
+  }
+  if (currentTranscriptLine.startTimestampMs <= currentTimeMs &&
+      currentTimeMs <= currentTranscriptLine.endTimestampMs) {
+    if (!isBolded(currentTranscriptLine)) {
+      addBold(currentTranscriptLine);
+    }
     return;
   }
   removeBold(currentTranscriptLine);
@@ -140,6 +144,11 @@ function removeBold(transcriptLineLiElement) {
 /** Checks if `transcriptLineLiElement` is bolded. */
 function isBolded(transcriptLineLiElement) {
   return transcriptLineLiElement.classList.contains(BOLD_FONT_WEIGHT);
+}
+
+function isWithinCurrentTimeRange(currentTimeMs) {
+  return currentTranscriptLine.startTimestampMs <= currentTimeMs &&
+  currentTimeMs <= currentTranscriptLine.endTimestampMs;
 }
 
 /**

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -126,7 +126,10 @@ function seekTranscript(currentTime) {
   // TODO: Handle the case where the video isn't only playing.
 }
 
-/** Bolds the text in `transcriptLineLiElement` */
+/** 
+ * Bolds the text in `transcriptLineLiElement` if it is not already
+ * bolded.
+ */
 function addBold(transcriptLineLiElement) {
   if (isBolded(transcriptLineLiElement)) {
     return;
@@ -135,7 +138,9 @@ function addBold(transcriptLineLiElement) {
   transcriptLineLiElement.classList.remove(DEFAULT_FONT_WEIGHT);
 }
 
-/** Removes bold from the text in `transcriptLineLiElement` */
+/** Removes bold from the text in `transcriptLineLiElement` if it
+ * is currently bolded.
+*/
 function removeBold(transcriptLineLiElement) {
   if (!isBolded(transcriptLineLiElement)) {
     return;

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -152,7 +152,8 @@ function isBolded(transcriptLineLiElement) {
 /**
  * Returns true if `currentTimeMs` is within the time range for
  * the current transcript line.
- * */
+ * 
+ */
 function isWithinCurrentTimeRange(currentTimeMs) {
   return currentTranscriptLine.startTimestampMs <= currentTimeMs &&
       currentTimeMs <= currentTranscriptLine.endTimestampMs;

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -128,7 +128,7 @@ function seekTranscript(currentTime) {
 
 /** Bolds the text in `transcriptLineLiElement` */
 function addBold(transcriptLineLiElement) {
-  if (isBolded) {
+  if (isBolded(transcriptLineLiElement)) {
     return;
   }
   transcriptLineLiElement.classList.add(BOLD_FONT_WEIGHT);
@@ -137,7 +137,7 @@ function addBold(transcriptLineLiElement) {
 
 /** Removes bold from the text in `transcriptLineLiElement` */
 function removeBold(transcriptLineLiElement) {
-  if (!isBolded) {
+  if (!isBolded(transcriptLineLiElement)) {
     return;
   }
   transcriptLineLiElement.classList.add(DEFAULT_FONT_WEIGHT);


### PR DESCRIPTION
The first transcript line is never bolded because the styling of a transcript line is only updated when the current transcript line is updated to be the next line.
This PR fixes that issue by adding additional checks in `seekTranscript`