### PR TITLE
Re-add URL slashes

### DIFF
--- a/src/main/java/com/googleinterns/zoomtube/servlets/LectureServlet.java
+++ b/src/main/java/com/googleinterns/zoomtube/servlets/LectureServlet.java
@@ -51,7 +51,7 @@ public class LectureServlet extends HttpServlet {
   /* Name of input field used for lecture video link in lecture selection page. */
   private static final String LINK_INPUT = "link-input";
 
-  private static final String REDIRECT_URL = "/view";
+  private static final String REDIRECT_URL = "/view/";
 
   /* Pattern used to create a matcher for a video ID. */
   private static Pattern videoUrlGeneratedPattern;

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -43,7 +43,7 @@
     </p>
   </div>
   <div id="view-btn-cont">
-    <a class="btn" href="/lectures">View list of lectures</a>
+    <a class="btn" href="/lectures/">View list of lectures</a>
   </div>
 </body>
 

--- a/src/main/webapp/lectures/lectures.js
+++ b/src/main/webapp/lectures/lectures.js
@@ -18,7 +18,7 @@ const ENDPOINT_LECTURE_LIST = '/lecture-list';
 const PARAM_ID = 'id';
 const PARAM_VIDEO_ID = 'video-id';
 
-const REDIRECT_PAGE = '/view';
+const REDIRECT_PAGE = '/view/';
 
 loadLectureList();
 

--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -21,7 +21,7 @@
 <body>
   <nav class="navbar navbar-light">
     <h2 id="header-text">ZoomTube</h2>
-    <a type="button" class="btn btn-outline-primary" href="/lectures">All Lectures</a>
+    <a type="button" class="btn btn-outline-primary" href="/lectures/">All Lectures</a>
   </nav>
 
   <div id="page">

--- a/src/test/java/com/googleinterns/zoomtube/servlets/LectureServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/LectureServletTest.java
@@ -88,7 +88,7 @@ public final class LectureServletTest {
     servlet.doPost(request, response);
 
     assertThat(datastoreService.prepare(new Query(LectureUtil.KIND)).countEntities()).isEqualTo(1);
-    verify(response).sendRedirect("/view?id=1");
+    verify(response).sendRedirect("/view/?id=1");
   }
 
   @Test
@@ -100,7 +100,7 @@ public final class LectureServletTest {
     servlet.doPost(request, response);
 
     assertThat(datastoreService.prepare(new Query(LectureUtil.KIND)).countEntities()).isEqualTo(1);
-    verify(response).sendRedirect("/view?id=1");
+    verify(response).sendRedirect("/view/?id=1");
   }
 
   @Test


### PR DESCRIPTION
The behavior of the deployed server varies from the local one.  It 404s unless a slash is included for viewing directories.  So, we need to add them back