### PR TITLE
Update height of the transcript container.

### DIFF
--- a/src/main/webapp/view/lecture-view.css
+++ b/src/main/webapp/view/lecture-view.css
@@ -71,7 +71,7 @@ discussion-comment {
 }
 
 #transcript-lines-container {
-  height: 90%;
+  height: calc(100% - 5rem);
   overflow: auto;
 }
 

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -138,9 +138,10 @@ function addBold(transcriptLineLiElement) {
   transcriptLineLiElement.classList.remove(DEFAULT_FONT_WEIGHT);
 }
 
-/** Removes bold from the text in `transcriptLineLiElement` if it
+/**
+ * Removes bold from the text in `transcriptLineLiElement` if it
  * is currently bolded.
-*/
+ */
 function removeBold(transcriptLineLiElement) {
   if (!isBolded(transcriptLineLiElement)) {
     return;


### PR DESCRIPTION
Currently, the transcript container is cut off on smaller screens. This PR updates the height to prevent that from happening.