### PR TITLE
Improve responsiveness of synchronization

### DIFF
--- a/src/main/webapp/synchronizer.js
+++ b/src/main/webapp/synchronizer.js
@@ -15,7 +15,7 @@
 let videoSyncTimer;
 let lastTime;
 
-const TIME_INTERVAL = 100;
+const TIME_INTERVAL_MS = 100;
 
 /**
  * Starts timer which broadcasts current video time every
@@ -24,7 +24,7 @@ const TIME_INTERVAL = 100;
 function startVideoSyncTimer() {
   videoSyncTimer = window.setInterval(() => {
     sync(window.videoPlayer.getCurrentTime());
-  }, /* ms= */ TIME_INTERVAL);
+  }, /* ms= */ TIME_INTERVAL_MS);
 }
 
 /**

--- a/src/main/webapp/synchronizer.js
+++ b/src/main/webapp/synchronizer.js
@@ -29,7 +29,8 @@ function startVideoSyncTimer() {
 
 /**
  * Calls functions that seek transcript, and discussion to {@code currentTime}
- * (number of seconds since video started playing).
+ * (number of seconds since start of video), when the {@code currentTime}
+ * changes from the last time this was called.
  */
 function sync(currentTime) {
   if (currentTime == lastTime) {

--- a/src/main/webapp/synchronizer.js
+++ b/src/main/webapp/synchronizer.js
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 let videoSyncTimer;
-const TIME_INTERVAL = 1000;
+let lastTime;
+
+const TIME_INTERVAL = 100;
 
 /**
  * Starts timer which broadcasts current video time every
@@ -25,16 +27,15 @@ function startVideoSyncTimer() {
   }, /* ms= */ TIME_INTERVAL);
 }
 
-/** Stops video sync timer. */
-function stopVideoSyncTimer() {
-  clearInterval(videoSyncTimer);
-}
-
 /**
  * Calls functions that seek transcript, and discussion to {@code currentTime}
  * (number of seconds since video started playing).
  */
 function sync(currentTime) {
+  if (currentTime == lastTime) {
+    return;
+  }
+  lastTime = currentTime;
   window.seekTranscript(currentTime);
   window.seekDiscussion(currentTime);
 }

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -138,9 +138,10 @@ function addBold(transcriptLineLiElement) {
   transcriptLineLiElement.classList.remove(DEFAULT_FONT_WEIGHT);
 }
 
-/** Removes bold from the text in `transcriptLineLiElement` if it
+/**
+ * Removes bold from the text in `transcriptLineLiElement` if it
  * is currently bolded.
-*/
+ */
 function removeBold(transcriptLineLiElement) {
   if (!isBolded(transcriptLineLiElement)) {
     return;

--- a/src/main/webapp/view/video/video.js
+++ b/src/main/webapp/view/video/video.js
@@ -34,7 +34,6 @@ function onYouTubeIframeAPIReady() {
     videoId: window.LECTURE.videoId,
     events: {
       onReady: onPlayerReady,
-      onStateChange: startOrStopTimer,
     },
   });
 }
@@ -42,15 +41,7 @@ function onYouTubeIframeAPIReady() {
 /** {@code event} plays the YouTube video. */
 function onPlayerReady(event) {
   event.target.playVideo();
-}
-
-/** Starts timer if {@code currentState} is playing, stops otherwise. */
-function startOrStopTimer(currentState) {
-  if (currentState.data == window.YT.PlayerState.PLAYING) {
-    window.startVideoSyncTimer();
-    return;
-  }
-  window.stopVideoSyncTimer();
+  window.startVideoSyncTimer();
 }
 
 /** Seeks video to {@code currentTime}. */


### PR DESCRIPTION
We want to make the synchronization feel more smooth:

- We increased the frequency of sync to 10 times per second (this can be reduced).

- In order to be able to update the time when a user seeks the video, the timer needs to be always running. We added a check to ensure we don't unnecessarily seek (if the time has changed since last seek).

Although the timer is always running, CPU usage remains at 0% when the video is paused.