### PR TITLE
Add function for scrolling the transcript to the very beginning.

### DIFF
--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -172,3 +172,15 @@ function scrollToTopOfTranscript(transcriptLine) {
   const ulElementOffset = transcriptLine.parentElement.offsetTop;
   transcriptContainer.scrollTop = transcriptLine.offsetTop - ulElementOffset;
 }
+
+/**
+ * Resets the transcript container to what it looks like before it
+ * started scrolling.
+ */
+function resetToBeforeTranscript() {
+  // TODO: Create a static reference to the first Transcript line once 
+  // a class is created for transcript line.
+  const firstTranscriptLine = document.getElementsByTagName('li')[0];
+  removeBold(currentTranscriptLine);
+  scrollToTopOfTranscript(firstTranscriptLine);
+}

--- a/src/main/webapp/view/transcript/transcript.js
+++ b/src/main/webapp/view/transcript/transcript.js
@@ -178,7 +178,7 @@ function scrollToTopOfTranscript(transcriptLine) {
  * started scrolling.
  */
 function resetToBeforeTranscript() {
-  // TODO: Create a static reference to the first Transcript line once 
+  // TODO: Create a static reference to the first Transcript line once
   // a class is created for transcript line.
   const firstTranscriptLine = document.getElementsByTagName('li')[0];
   removeBold(currentTranscriptLine);


### PR DESCRIPTION
This pull request creates a function will be called in `seekTranscript` when the current video time is before the start of any transcript line. It will ensure that the transcript is scrolled to the very top and the current line is no longer highlighted.

Edit: Having a separate set of function calls for times before the transcript is unnecessary. Instead, it would be cleaner to deal when searching for the closest line. Thus, this pull request will close.