### PR TITLE
Add banner for continuing auto-scroll in the transcript.

### DIFF
--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -30,7 +30,9 @@
       <div id="player"></div>
       <div id="transcript-container">
         <h2>Transcript:</h2>
-        <div id="transcript-lines-container" class="mx-5 my-3 bg-light pb-3 pt-4 rounded"></div>
+        <div id="transcript-lines-container" class="mx-5 my-3 bg-light pb-3 rounded">
+          <div id="scroll-banner" class="bg-primary sticky-top p-2 text-center">Click here to continue auto-scroll</div>
+        </div>
       </div>
     </div>
     <div class="halfpage" id="discussion">

--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -31,7 +31,7 @@
       <div id="transcript-container">
         <h2>Transcript:</h2>
         <div id="transcript-lines-container" class="mx-5 my-3 bg-light pb-3 rounded">
-          <div id="scroll-banner" class="sticky-top p-2 text-center text-white font-weight-bold">
+          <div id="scroll-banner" class="sticky-top p-2 text-center text-white">
             Click here to continue auto-scroll
           </div>
         </div>

--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -31,7 +31,9 @@
       <div id="transcript-container">
         <h2>Transcript:</h2>
         <div id="transcript-lines-container" class="mx-5 my-3 bg-light pb-3 rounded">
-          <div id="scroll-banner" class="sticky-top p-2 text-center text-white font-weight-bold">Click here to continue auto-scroll</div>
+          <div id="scroll-banner" class="sticky-top p-2 text-center text-white font-weight-bold">
+            Click here to continue auto-scroll
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -31,7 +31,7 @@
       <div id="transcript-container">
         <h2>Transcript:</h2>
         <div id="transcript-lines-container" class="mx-5 my-3 bg-light pb-3 rounded">
-          <div id="scroll-banner" class="bg-primary sticky-top p-2 text-center">Click here to continue auto-scroll</div>
+          <div id="scroll-banner" class="sticky-top p-2 text-center text-white font-weight-bold">Click here to continue auto-scroll</div>
         </div>
       </div>
     </div>

--- a/src/main/webapp/view/lecture-view.css
+++ b/src/main/webapp/view/lecture-view.css
@@ -67,6 +67,7 @@ discussion-comment {
 /* Transcript */
 
 #scroll-banner {
+  background-color: #4c8bf5;
   visibility: hidden;
 }
 

--- a/src/main/webapp/view/lecture-view.css
+++ b/src/main/webapp/view/lecture-view.css
@@ -66,6 +66,10 @@ discussion-comment {
 
 /* Transcript */
 
+#scroll-banner {
+  visibility: hidden;
+}
+
 #transcript-container {
   height: calc(100% - 390px);
 }


### PR DESCRIPTION
By default, the banner is invisible. Additionally, this banner stays fixed to the top of the transcript container even as the user scrolls.

In a different pull request, this banner will appear when auto scrolling is disabled. 

Banner is hidden: https://screenshot.googleplex.com/d9b32f50-45bf-4ec5-bb94-9b39f1115abb.png
Banner is visible: https://screenshot.googleplex.com/75035106-9adb-4da8-a288-be3d8b2f4e0e.png
Banner stays fixed even after scrolling: https://screenshot.googleplex.com/d9b1aaed-5841-42de-a66c-b1e7d2f4caab.png