### PR TITLE
Reformat HTML to satisfy updated linter

### DIFF
--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -41,9 +41,7 @@
           <label for="post-textarea">Leave a Comment at <span id="timestamp-span">00:00</span></label>
           <textarea class="form-control" id="post-textarea" rows="2"></textarea>
         </div>
-        <button class="btn btn-primary mb-2" type="button" onclick="postNewComment()">
-          Post Comment
-        </button>
+        <button class="btn btn-primary mb-2" type="button" onclick="postNewComment()">Post Comment</button>
       </div>
       <div class="container" id="discussion-comments"></div>
     </div>
@@ -65,9 +63,7 @@
       <div class="comment-content">
         <div><slot name="content"></slot></div>
         <div class="actions-bar">
-          <button type="button" class="btn btn-primary btn-sm" id="show-reply">
-            Reply
-          </button>
+          <button type="button" class="btn btn-primary btn-sm" id="show-reply">Reply</button>
         </div>
       </div>
       <div class="replies">


### PR DESCRIPTION
`html-validate` had an update, which slightly changed how our HTML should be formatted.  This performs those changes so our other branches will stop failing the linter.