### PR TITLE
Remove global button style overrides, and restyle discussion buttons

### DIFF
--- a/src/main/webapp/global.css
+++ b/src/main/webapp/global.css
@@ -11,21 +11,7 @@
   font-family: 'Product Sans';
 }
 
-body,
-html {
-  height: 100vh;
-  max-height: 100vh;
-  max-width: 100vw;
-  width: 100vw;
-  overflow: hidden;
-}
-
-body {
-  margin-bottom: 60px !important;
-}
-
 #footer {
-  bottom: 0;
   height: 60px;
   line-height: 60px;
   padding-top: 0px !important;
@@ -46,14 +32,14 @@ body {
   margin-bottom: 0 !important;
 }
 
-/* Buttons */
+/* Zoomtube Buttons */
 
-.btn {
+.zt-btn {
   border-color: #4c8bf5 !important;
   border-radius: 50px !important;
 }
 
-.btn:hover {
+.zt-btn:hover {
   background-color: #4c8bf5 !important;
 }
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -44,7 +44,7 @@
     </p>
   </div>
   <div id="view-btn-cont">
-    <a class="btn" href="/lectures/">View list of lectures</a>
+    <a class="btn zt-btn" href="/lectures/">View list of lectures</a>
   </div>
 </body>
 

--- a/src/main/webapp/landing-page.css
+++ b/src/main/webapp/landing-page.css
@@ -12,7 +12,7 @@
   align-items: center !important;
   display: flex !important;
   justify-content: center !important;
-  margin: 30px auto auto auto;
+  margin: 30px auto 60px;
 }
 
 #view-btn-cont a {

--- a/src/main/webapp/lectures/index.html
+++ b/src/main/webapp/lectures/index.html
@@ -17,7 +17,6 @@
 <body>
   <nav class="navbar navbar-light">
     <h2><a href="/" id="header-text">ZoomTube</a></h2>
-    <button type="button" class="btn btn-outline-primary btn-wide">Logout</button>
   </nav>
 
   <div id="list-cont">
@@ -31,7 +30,7 @@
   </div>
 
   <div id="add-btn-cont">
-    <button type="button" class="btn btn-primary btn-wider" data-toggle="modal" data-target="#addLectureModal">
+    <button type="button" class="zt-btn btn btn-primary btn-wider" data-toggle="modal" data-target="#addLectureModal">
       Add a Lecture
     </button>
   </div>
@@ -62,7 +61,7 @@
             <input type="url" class="form-control" placeholder="Lecture YouTube URL" name="link-input" required />
             <br />
             <div id="submit-btn-cont">
-              <button type="submit" class="btn btn-primary btn-wide">Submit</button>
+              <button type="submit" class="zt-btn btn btn-primary btn-wide">Submit</button>
             </div>
           </form>
         </div>

--- a/src/main/webapp/lectures/lecture-list.css
+++ b/src/main/webapp/lectures/lecture-list.css
@@ -4,7 +4,7 @@
   align-items: center !important;
   display: flex !important;
   justify-content: center !important;
-  margin: 30px auto auto auto;
+  margin: 30px auto 60px;
 }
 
 #add-btn-cont .btn,

--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -83,8 +83,8 @@
         <div id="reply-form" class="collapse">
           <textarea class="form-control" id="reply-textarea" rows="3"></textarea>
           <div class="actions-bar">
-            <button class="btn btn-sm btn-link mb-2" type="button" id="post-reply">Post</button>
             <button class="btn btn-sm btn-link mb-2" type="button" id="cancel-reply">Cancel</button>
+            <button class="zt-btn btn btn-sm btn-primary mb-2" type="button" id="post-reply">Post Reply</button>
           </div>
         </div>
         <slot name="replies"></slot>

--- a/src/main/webapp/view/index.html
+++ b/src/main/webapp/view/index.html
@@ -24,7 +24,7 @@
 <body>
   <nav class="navbar navbar-light">
     <h2 id="header-text">ZoomTube</h2>
-    <a type="button" class="btn btn-outline-primary" href="/lectures/">All Lectures</a>
+    <a type="button" class="btn zt-btn btn-outline-primary" href="/lectures/">All Lectures</a>
   </nav>
 
   <div id="page">
@@ -48,7 +48,9 @@
           <label for="post-textarea">Leave a Comment at <span id="timestamp-span">00:00</span></label>
           <textarea class="form-control" id="post-textarea" rows="2"></textarea>
         </div>
-        <button class="btn btn-primary mb-2 float-right" type="button" onclick="postNewComment()">Post Comment</button>
+        <button class="zt-btn btn btn-primary mb-2 float-right" type="button" onclick="postNewComment()">
+          Post Comment
+        </button>
       </div>
       <div class="container" id="discussion-comments"></div>
     </div>
@@ -74,15 +76,15 @@
       <div class="comment-content">
         <div><slot name="content"></slot></div>
         <div class="actions-bar">
-          <button type="button" class="btn btn-primary btn-sm" id="show-reply">Reply</button>
+          <button type="button" class="btn btn-link btn-sm" id="show-reply">Reply</button>
         </div>
       </div>
       <div class="replies">
         <div id="reply-form" class="collapse">
           <textarea class="form-control" id="reply-textarea" rows="3"></textarea>
           <div class="actions-bar">
-            <button class="btn btn-sm btn-primary mb-2" type="button" id="post-reply">Post</button>
-            <button class="btn btn-sm btn-secondary mb-2" type="button" id="cancel-reply">Cancel</button>
+            <button class="btn btn-sm btn-link mb-2" type="button" id="post-reply">Post</button>
+            <button class="btn btn-sm btn-link mb-2" type="button" id="cancel-reply">Cancel</button>
           </div>
         </div>
         <slot name="replies"></slot>

--- a/src/main/webapp/view/lecture-view.css
+++ b/src/main/webapp/view/lecture-view.css
@@ -1,5 +1,18 @@
 /* Layout */
 
+body,
+html {
+  height: 100vh;
+  max-height: 100vh;
+  max-width: 100vw;
+  width: 100vw;
+  overflow: hidden;
+}
+
+body {
+  margin-bottom: 60px !important;
+}
+
 .halfpage {
   height: calc(100vh - 56px);
   overflow: hidden;

--- a/src/main/webapp/view/lecture-view.css
+++ b/src/main/webapp/view/lecture-view.css
@@ -30,6 +30,10 @@ body {
   text-align: right;
 }
 
+#cancel-reply {
+  color: #555;
+}
+
 .comment-content {
   background: #fff;
   border: 2px solid #eee;

--- a/src/main/webapp/view/lecture-view.css
+++ b/src/main/webapp/view/lecture-view.css
@@ -5,8 +5,8 @@ html {
   height: 100vh;
   max-height: 100vh;
   max-width: 100vw;
-  width: 100vw;
   overflow: hidden;
+  width: 100vw;
 }
 
 body {


### PR DESCRIPTION
Continuation of restyling as started in #282 

Previously, `btn` style was being overrided globally, which made it impossible to use some built in button styles, like `btn-link`.  This PR introduces `zt-btn` for those custom styles. 

This also move some other global styles to their own page, which were messing with other things.  For instance, the lecture-list page can now scroll.

Screenshots
- Large screen: https://screenshot.googleplex.com/7XXqrmaP4KBtWp2
- Small screen: https://screenshot.googleplex.com/4oLUSfR6ifNDk5Y
- Close of up reply form (disregard reply form in other screenshots, they are outdated): https://screenshot.googleplex.com/BfQqZCGB7XdrHF3

This should be it for major restyling.
