### PR TITLE
Send redirect even on transcript error

### DIFF
--- a/src/main/java/com/googleinterns/zoomtube/servlets/LectureServlet.java
+++ b/src/main/java/com/googleinterns/zoomtube/servlets/LectureServlet.java
@@ -94,7 +94,13 @@ public class LectureServlet extends HttpServlet {
     String lectureName = request.getParameter(PARAM_NAME);
     Entity lectureEntity = LectureUtil.createEntity(lectureName, videoUrl, videoId.get());
     datastore.put(lectureEntity);
-    initializeTranscript(lectureEntity);
+    try {
+      initializeTranscript(lectureEntity);
+    } catch (IOException | ServletException e) {
+      // If there was an error initializing the transcript, then this lecture won't have one.
+      // Luckily that's still ok, so we suppress these errors so we can redirect.
+      // We might want to log these somewhere, but that's beyond the scope of this project.
+    }
     response.sendRedirect(buildRedirectUrl(lectureEntity));
   }
 

--- a/src/test/java/com/googleinterns/zoomtube/servlets/LectureServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/LectureServletTest.java
@@ -125,8 +125,7 @@ public final class LectureServletTest {
   }
 
   @Test
-  public void doPost_videoHasNoTranscript_shouldReturnLectureAnyways()
-      throws IOException, ServletException {
+  public void doPost_videoHasNoTranscript_shouldReturnLectureAnyways() throws Exception {
     when(request.getParameter(LectureServlet.PARAM_NAME)).thenReturn(TEST_NAME);
     when(request.getParameter(LectureServlet.PARAM_LINK)).thenReturn(NO_TRANSCRIPT_LINK);
     datastoreService.put(LectureUtil.createEntity(TEST_NAME, NO_TRANSCRIPT_LINK, NO_TRANSCRIPT_ID));

--- a/src/test/java/com/googleinterns/zoomtube/servlets/LectureServletTest.java
+++ b/src/test/java/com/googleinterns/zoomtube/servlets/LectureServletTest.java
@@ -62,6 +62,8 @@ public final class LectureServletTest {
   private static final String TEST_NAME = "TestName";
   private static final String TEST_LINK = "https://www.youtube.com/watch?v=3ymwOvzhwHs";
   private static final String TEST_ID = "3ymwOvzhwHs";
+  private static final String NO_TRANSCRIPT_LINK = "https://www.youtube.com/watch?v=F6VnkwBBI1k";
+  private static final String NO_TRANSCRIPT_ID = "F6VnkwBBI1k";
 
   @Before
   public void setUp() throws ServletException, IOException {
@@ -115,6 +117,19 @@ public final class LectureServletTest {
     when(request.getParameter(LectureServlet.PARAM_NAME)).thenReturn(TEST_NAME);
     when(request.getParameter(LectureServlet.PARAM_LINK)).thenReturn(TEST_LINK);
     datastoreService.put(LectureUtil.createEntity(TEST_NAME, TEST_LINK, TEST_ID));
+
+    servlet.doPost(request, response);
+
+    assertThat(datastoreService.prepare(new Query(LectureUtil.KIND)).countEntities()).isEqualTo(1);
+    verify(response).sendRedirect("/view/?id=1");
+  }
+
+  @Test
+  public void doPost_videoHasNoTranscript_shouldReturnLectureAnyways()
+      throws IOException, ServletException {
+    when(request.getParameter(LectureServlet.PARAM_NAME)).thenReturn(TEST_NAME);
+    when(request.getParameter(LectureServlet.PARAM_LINK)).thenReturn(NO_TRANSCRIPT_LINK);
+    datastoreService.put(LectureUtil.createEntity(TEST_NAME, NO_TRANSCRIPT_LINK, NO_TRANSCRIPT_ID));
 
     servlet.doPost(request, response);
 


### PR DESCRIPTION
Now that we have a nice message for empty transcripts, it's ok to simply redirect the user to the lecture view when we fail to initialize the transcript.

Closes: #284 