### PR TITLE
Make footer stick to bottom of window if possible

### DIFF
--- a/src/main/webapp/global.css
+++ b/src/main/webapp/global.css
@@ -12,9 +12,7 @@
 }
 
 #footer {
-  height: 60px;
-  line-height: 60px;
-  padding-top: 0px !important;
+  bottom: 0;
   position: absolute;
   width: 100%;
 }

--- a/src/main/webapp/landing-page.css
+++ b/src/main/webapp/landing-page.css
@@ -1,3 +1,11 @@
+/* Layout */
+
+body {
+  min-height: 100vh;
+  padding-bottom: 50px;
+  position: relative;
+}
+
 /* Text */
 
 #text {

--- a/src/main/webapp/lectures/lecture-list.css
+++ b/src/main/webapp/lectures/lecture-list.css
@@ -1,3 +1,11 @@
+/* Layout */
+
+body {
+  min-height: 100vh;
+  padding-bottom: 50px;
+  position: relative;
+}
+
 /* List page */
 
 #add-btn-cont {


### PR DESCRIPTION
Footer stays at the bottom, with at least a 50px-ish padding on top.

If the window is too small, a scroll bar appears and the footer goes out of view.

Closes: #346 