### PR TITLE
Remove unused dependencies from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,6 @@
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
 
-  <repositories>
-    <!-- Repository for Google-PerspectiveAPI-Java-Client. -->
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -70,11 +62,6 @@
       <version>1.1.0</version>
     </dependency>
     <dependency>
-    <groupId>com.github.origma</groupId>
-      <artifactId>Google-PerspectiveAPI-Java-Client</artifactId>
-      <version>0.0.5</version>
-    </dependency>
-      <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>


### PR DESCRIPTION
There's still one unused dependency, `google-cloud-secretsmanager`.  However, it seems like it adds some Apache http packages, because removing it results in the following compiler errors:
```
Compilation failure: 
[ERROR] /usr/local/google/home/nwach/zoomtube/src/main/java/com/googleinterns/zoomtube/transcriptParser/TranscriptParser.java:[32,36] package org.apache.http.client.utils does not exist
[ERROR] /usr/local/google/home/nwach/zoomtube/src/main/java/com/googleinterns/zoomtube/servlets/LectureServlet.java:[41,36] package org.apache.http.client.utils does not exist
```
If someone wants to dig and figure out what we should replace it with, go ahead.  For now I'll leave it be.