### PR TITLE
Update Discussion Comments in background

### DIFF
--- a/src/main/webapp/view/discussion/discussion-area.js
+++ b/src/main/webapp/view/discussion/discussion-area.js
@@ -35,6 +35,11 @@ export default class DiscussionArea {
    * selected type button in the new comment area.
    */
   static #SELECTOR_SELECTED_TYPE = 'label.active > input';
+  /**
+   * How long to wait between updating the discussion comments in the
+   * background.
+   */
+  static #BACKGROUND_UPDATE_INTERVAL_MS = 5000;
 
   #lecture;
   #eventController;
@@ -73,6 +78,10 @@ export default class DiscussionArea {
     // This is used as the `onclick` handler of the new comment area submit
     // button. It must be set after discussion is initialized.
     window.postNewComment = this.postNewComment.bind(this);
+
+    setInterval(
+        this.updateDiscussion.bind(this),
+        DiscussionArea.#BACKGROUND_UPDATE_INTERVAL_MS);
     await this.updateDiscussion();
   }
 


### PR DESCRIPTION
This runs `updateDiscussion` every 5 seconds in the background.

I thought this was already a feature