### PR TITLE
Fix issue where comments can not be posted if there is no transcript.

### DIFF
--- a/src/main/webapp/view/discussion/discussion-area.js
+++ b/src/main/webapp/view/discussion/discussion-area.js
@@ -241,8 +241,10 @@ export default class DiscussionArea {
 
     const currentTranscriptLine =
         this.#transcriptSeeker.currentTranscriptLine();
-    const currentTranscriptLineId =
-        currentTranscriptLine.transcriptLine.transcriptKey.id;
+    let currentTranscriptLineId;
+    if (currentTranscriptLine) {
+      currentTranscriptLineId = currentTranscriptLine.transcriptLine.transcriptKey.id;
+    }
 
     this.#manager
         .postRootComment(

--- a/src/main/webapp/view/discussion/discussion-area.js
+++ b/src/main/webapp/view/discussion/discussion-area.js
@@ -241,8 +241,8 @@ export default class DiscussionArea {
 
     const currentTranscriptLine =
         this.#transcriptSeeker.currentTranscriptLine();
-    let currentTranscriptLineId;
-    if (currentTranscriptLine) {
+    let currentTranscriptLineId = null;
+    if (currentTranscriptLine != null) {
       currentTranscriptLineId =
           currentTranscriptLine.transcriptLine.transcriptKey.id;
     }

--- a/src/main/webapp/view/discussion/discussion-area.js
+++ b/src/main/webapp/view/discussion/discussion-area.js
@@ -243,7 +243,8 @@ export default class DiscussionArea {
         this.#transcriptSeeker.currentTranscriptLine();
     let currentTranscriptLineId;
     if (currentTranscriptLine) {
-      currentTranscriptLineId = currentTranscriptLine.transcriptLine.transcriptKey.id;
+      currentTranscriptLineId =
+          currentTranscriptLine.transcriptLine.transcriptKey.id;
     }
 
     this.#manager

--- a/src/main/webapp/view/discussion/discussion-area.js
+++ b/src/main/webapp/view/discussion/discussion-area.js
@@ -126,8 +126,11 @@ export default class DiscussionArea {
       const commentElement = new DiscussionComment(this);
       commentElement.setComment(comment);
       comment.element = commentElement;
-      this.#transcriptArea.incrementCommentIndicatorAt(
-          comment.transcriptLineKey.value.id);
+      console.log(comment);
+      if (comment.transcriptLineKey.value != null) {
+        this.#transcriptArea.incrementCommentIndicatorAt(
+            comment.transcriptLineKey.value.id);
+      }
     }
 
     // Insert comments.

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -114,7 +114,7 @@ export default class DiscussionManager {
   }
 
   /**
-   * Posts `content` to the discussion with the given `paramsMap`.
+   * Posts `content` to the discussion with the given `paramNamesTo`.
    * This method is private and should only be called within
    * `DiscussionManager`.
    *
@@ -122,16 +122,16 @@ export default class DiscussionManager {
    * `PARAM_TIMESTAMP` or `PARAM_PARENT`. The caller should ensure the correct
    * parameters are supplied for the type of comment being posted.
    */
-  async postComment(content, paramsMap) {
+  async postComment(content, paramNamesTo) {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
-    for (const paramName in paramsMap) {
+    for (const paramName in paramNamesTo) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (paramsMap.hasOwnProperty(paramName) &&
-          paramsMap[paramName] !== null) {
-        url.searchParams.append(paramName, paramsMap[paramName]);
+      let commentParamValue = paramNamesTo[paramName];
+      if (paramNamesTo.hasOwnProperty(paramName) && commentParamValue != null) {
+        url.searchParams.append(paramName, paramNamesTo[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -114,9 +114,9 @@ export default class DiscussionManager {
   }
 
   /**
-   * Posts `content` to the discussion with the given `commentParameterNameToValue`.
-   * This method is private and should only be called within
-   * `DiscussionManager`.
+   * Posts `content` to the discussion with the given
+   * `commentParameterNameToValue`. This method is private and should only be
+   * called within `DiscussionManager`.
    *
    * <p>Different types of comments require different parameters, such as
    * `PARAM_TIMESTAMP` or `PARAM_PARENT`. The caller should ensure the correct
@@ -131,7 +131,8 @@ export default class DiscussionManager {
       /* eslint-disable no-prototype-builtins */
       if (commentParameterNameToValue.hasOwnProperty(paramName) &&
           commentParameterNameToValue[paramName] !== null) {
-        url.searchParams.append(paramName, commentParameterNameToValue[paramName]);
+        url.searchParams.append(
+            paramName, commentParameterNameToValue[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -137,7 +137,6 @@ export default class DiscussionManager {
       /* eslint-enable no-prototype-builtins */
     }
 
-
     await fetch(url, {
       method: 'POST',
       body: content,

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -114,7 +114,7 @@ export default class DiscussionManager {
   }
 
   /**
-   * Posts `content` to the discussion with the given `parameterNameToValue`.
+   * Posts `content` to the discussion with the given `commentParameterNameToValue`.
    * This method is private and should only be called within
    * `DiscussionManager`.
    *
@@ -122,16 +122,16 @@ export default class DiscussionManager {
    * `PARAM_TIMESTAMP` or `PARAM_PARENT`. The caller should ensure the correct
    * parameters are supplied for the type of comment being posted.
    */
-  async postComment(content, parameterNameToValue) {
+  async postComment(content, commentParameterNameToValue) {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
-    for (const paramName in parameterNameToValue) {
+    for (const paramName in commentParameterNameToValue) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (parameterNameToValue.hasOwnProperty(paramName) &&
-          parameterNameToValue[paramName] !== null) {
-        url.searchParams.append(paramName, parameterNameToValue[paramName]);
+      if (commentParameterNameToValue.hasOwnProperty(paramName) &&
+          commentParameterNameToValue[paramName] !== null) {
+        url.searchParams.append(paramName, commentParameterNameToValue[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -127,9 +127,9 @@ export default class DiscussionManager {
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
     for (const paramName in paramNamesTo) {
+      const commentParamValue = paramNamesTo[paramName];
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      let commentParamValue = paramNamesTo[paramName];
       if (paramNamesTo.hasOwnProperty(paramName) && commentParamValue != null) {
         url.searchParams.append(paramName, paramNamesTo[paramName]);
       }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -128,7 +128,7 @@ export default class DiscussionManager {
     for (const param in params) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (params.hasOwnProperty(param) && params[param]) {
+      if (params.hasOwnProperty(param) && params[param] != null) {
         url.searchParams.append(param, params[param]);
       }
       /* eslint-enable no-prototype-builtins */

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -114,7 +114,7 @@ export default class DiscussionManager {
   }
 
   /**
-   * Posts `content` to the discussion with the given `parameterNamesToValue`.
+   * Posts `content` to the discussion with the given `parameterNameToValue`.
    * This method is private and should only be called within
    * `DiscussionManager`.
    *
@@ -122,16 +122,16 @@ export default class DiscussionManager {
    * `PARAM_TIMESTAMP` or `PARAM_PARENT`. The caller should ensure the correct
    * parameters are supplied for the type of comment being posted.
    */
-  async postComment(content, parameterNamesToValue) {
+  async postComment(content, parameterNameToValue) {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
-    for (const paramName in parameterNamesToValue) {
+    for (const paramName in parameterNameToValue) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (parameterNamesToValue.hasOwnProperty(paramName) &&
-          parameterNamesToValue[paramName] !== null) {
-        url.searchParams.append(paramName, parameterNamesToValue[paramName]);
+      if (parameterNameToValue.hasOwnProperty(paramName) &&
+          parameterNameToValue[paramName] !== null) {
+        url.searchParams.append(paramName, parameterNameToValue[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -129,7 +129,8 @@ export default class DiscussionManager {
     for (const paramName in paramsMap) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (paramsMap.hasOwnProperty(paramName) && paramsMap[paramName] !== null) {
+      if (paramsMap.hasOwnProperty(paramName) &&
+          paramsMap[paramName] !== null) {
         url.searchParams.append(paramName, paramsMap[paramName]);
       }
       /* eslint-enable no-prototype-builtins */

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -92,8 +92,10 @@ export default class DiscussionManager {
   /**
    * Posts `content` as a new root comment at `timestampMs` with the specified
    * `type` and `transcriptLineId`.
+   * 
+   * <p>If `transcriptLineId` is undefined, it is set to an empty string.
    */
-  async postRootComment(content, timestampMs, type, transcriptLineId) {
+  async postRootComment(content, timestampMs, type, transcriptLineId = "") {
     await this.postComment(content, {
       [DiscussionManager.#PARAM_TIMESTAMP]: timestampMs,
       [DiscussionManager.#PARAM_TYPE]: type,
@@ -104,8 +106,10 @@ export default class DiscussionManager {
   /**
    * Posts `content` as a reply to `parentId` with the specified
    * `transcriptLineId`.
+   *
+   * <p>If `transcriptLineId` is undefined, it is set to an empty string.
    */
-  async postReply(content, parentId, transcriptLineId) {
+  async postReply(content, parentId, transcriptLineId = "") {
     await this.postComment(content, {
       [DiscussionManager.#PARAM_PARENT]: parentId,
       [DiscussionManager.#PARAM_TYPE]: COMMENT_TYPE_REPLY,

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -92,10 +92,8 @@ export default class DiscussionManager {
   /**
    * Posts `content` as a new root comment at `timestampMs` with the specified
    * `type` and `transcriptLineId`.
-   * 
-   * <p>If `transcriptLineId` is undefined, it is set to an empty string.
    */
-  async postRootComment(content, timestampMs, type, transcriptLineId = "") {
+  async postRootComment(content, timestampMs, type, transcriptLineId) {
     await this.postComment(content, {
       [DiscussionManager.#PARAM_TIMESTAMP]: timestampMs,
       [DiscussionManager.#PARAM_TYPE]: type,
@@ -106,10 +104,8 @@ export default class DiscussionManager {
   /**
    * Posts `content` as a reply to `parentId` with the specified
    * `transcriptLineId`.
-   *
-   * <p>If `transcriptLineId` is undefined, it is set to an empty string.
    */
-  async postReply(content, parentId, transcriptLineId = "") {
+  async postReply(content, parentId, transcriptLineId) {
     await this.postComment(content, {
       [DiscussionManager.#PARAM_PARENT]: parentId,
       [DiscussionManager.#PARAM_TYPE]: COMMENT_TYPE_REPLY,
@@ -132,7 +128,7 @@ export default class DiscussionManager {
     for (const param in params) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (params.hasOwnProperty(param)) {
+      if (params.hasOwnProperty(param) && params[param]) {
         url.searchParams.append(param, params[param]);
       }
       /* eslint-enable no-prototype-builtins */

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -126,8 +126,6 @@ export default class DiscussionManager {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
-
-
     for (const paramName in paramNamesTo) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -126,15 +126,18 @@ export default class DiscussionManager {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
+
+
     for (const paramName in paramNamesTo) {
-      const commentParamValue = paramNamesTo[paramName];
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (paramNamesTo.hasOwnProperty(paramName) && commentParamValue != null) {
+      if (paramNamesTo.hasOwnProperty(paramName) &&
+          paramNamesTo[paramName] !== null) {
         url.searchParams.append(paramName, paramNamesTo[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }
+
 
     await fetch(url, {
       method: 'POST',

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -114,22 +114,23 @@ export default class DiscussionManager {
   }
 
   /**
-   * Posts `content` to the discussion with the given `params`.  This method is
-   * private and should only be called within `DiscussionManager`.
+   * Posts `content` to the discussion with the given `paramsMap`.
+   * This method is private and should only be called within
+   * `DiscussionManager`.
    *
    * <p>Different types of comments require different parameters, such as
    * `PARAM_TIMESTAMP` or `PARAM_PARENT`. The caller should ensure the correct
    * parameters are supplied for the type of comment being posted.
    */
-  async postComment(content, params) {
+  async postComment(content, paramsMap) {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
-    for (const param in params) {
+    for (const paramName in paramsMap) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (params.hasOwnProperty(param) && params[param] !== null) {
-        url.searchParams.append(param, params[param]);
+      if (paramsMap.hasOwnProperty(paramName) && paramsMap[paramName] !== null) {
+        url.searchParams.append(paramName, paramsMap[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -114,7 +114,7 @@ export default class DiscussionManager {
   }
 
   /**
-   * Posts `content` to the discussion with the given `paramNamesTo`.
+   * Posts `content` to the discussion with the given `parameterNamesToValue`.
    * This method is private and should only be called within
    * `DiscussionManager`.
    *
@@ -122,16 +122,16 @@ export default class DiscussionManager {
    * `PARAM_TIMESTAMP` or `PARAM_PARENT`. The caller should ensure the correct
    * parameters are supplied for the type of comment being posted.
    */
-  async postComment(content, paramNamesTo) {
+  async postComment(content, parameterNamesToValue) {
     const url = new URL(DiscussionManager.#ENDPOINT, window.location.origin);
     url.searchParams.append(
         DiscussionManager.#PARAM_LECTURE, this.#lecture.key.id);
-    for (const paramName in paramNamesTo) {
+    for (const paramName in parameterNamesToValue) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (paramNamesTo.hasOwnProperty(paramName) &&
-          paramNamesTo[paramName] !== null) {
-        url.searchParams.append(paramName, paramNamesTo[paramName]);
+      if (parameterNamesToValue.hasOwnProperty(paramName) &&
+          parameterNamesToValue[paramName] !== null) {
+        url.searchParams.append(paramName, parameterNamesToValue[paramName]);
       }
       /* eslint-enable no-prototype-builtins */
     }

--- a/src/main/webapp/view/discussion/discussion-manager.js
+++ b/src/main/webapp/view/discussion/discussion-manager.js
@@ -128,7 +128,7 @@ export default class DiscussionManager {
     for (const param in params) {
       // This is recommended by the style guide, but disallowed by linter.
       /* eslint-disable no-prototype-builtins */
-      if (params.hasOwnProperty(param) && params[param] != null) {
+      if (params.hasOwnProperty(param) && params[param] !== null) {
         url.searchParams.append(param, params[param]);
       }
       /* eslint-enable no-prototype-builtins */


### PR DESCRIPTION
This change ensures that the `transcriptLineId` is defined before adding it to get request URL.